### PR TITLE
Makefile: Switch to to simpler and better CPU opts scheme for A78+A55 BIG.little execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -735,7 +735,7 @@ KBUILD_CFLAGS   += -Os
 else
 KBUILD_CFLAGS   += -O3
 ifeq ($(cc-name),clang)
-KBUILD_CFLAGS	+= -mcpu=cortex-a55 -mtune=cortex-a55
+KBUILD_CFLAGS	+= -mcpu='cortex-a78.cortex-a55'
 endif
 endif
 

--- a/drivers/input/touchscreen/oplus_touchscreen/touchpanel_common.h
+++ b/drivers/input/touchscreen/oplus_touchscreen/touchpanel_common.h
@@ -58,6 +58,21 @@
 #define Down2UpSwip         11  // |^
 #define Mgestrue            12  // M
 #define Wgestrue            13  // W
+#define KEY_GESTURE_W               246
+#define KEY_GESTURE_M               247
+#define KEY_GESTURE_S               248
+#define KEY_DOUBLE_TAP              KEY_WAKEUP
+#define KEY_GESTURE_CIRCLE          250
+#define KEY_GESTURE_TWO_SWIPE       251
+#define KEY_GESTURE_UP_ARROW        252
+#define KEY_GESTURE_LEFT_ARROW      253
+#define KEY_GESTURE_RIGHT_ARROW     254
+#define KEY_GESTURE_DOWN_ARROW      255
+#define KEY_GESTURE_SWIPE_LEFT      KEY_F5
+#define KEY_GESTURE_SWIPE_DOWN      KEY_F6
+#define KEY_GESTURE_SWIPE_RIGHT     KEY_F7
+#define KEY_GESTURE_SWIPE_UP        KEY_F8
+#define KEY_GESTURE_SINGLE_TAP      KEY_F9
 #define FingerprintDown     14
 #define FingerprintUp       15
 #define SingleTap           16

--- a/drivers/input/touchscreen/oplus_touchscreen/touchpanel_common_driver.c
+++ b/drivers/input/touchscreen/oplus_touchscreen/touchpanel_common_driver.c
@@ -82,6 +82,21 @@ unsigned int tp_register_times = 0;
 struct touchpanel_data *g_tp = NULL;
 static DECLARE_WAIT_QUEUE_HEAD(waiter);
 
+uint8_t DouTap_enable = 0;				 // double tap
+uint8_t UpVee_enable  = 0;				 // V
+uint8_t DownVee_enable  = 0;			 // ^
+uint8_t LeftVee_enable = 0; 			 // >
+uint8_t RightVee_enable = 0;			 // <
+uint8_t Circle_enable = 0;				 // O
+uint8_t DouSwip_enable = 0; 			 // ||
+uint8_t Left2RightSwip_enable = 0;		 // -->
+uint8_t Right2LeftSwip_enable = 0;		 // <--
+uint8_t Up2DownSwip_enable = 0;			 // |v
+uint8_t Down2UpSwip_enable = 0;			 // |^
+uint8_t Mgestrue_enable = 0;			 // M
+uint8_t Wgestrue_enable = 0;			 // W
+uint8_t Enable_gesture = 0;
+
 struct seq_file *s111;
 
 
@@ -462,7 +477,9 @@ static void tp_geture_info_transform(struct gesture_info *gesture, struct resolu
 
 static void tp_gesture_handle(struct touchpanel_data *ts)
 {
-    struct gesture_info gesture_info_temp;
+	struct gesture_info gesture_info_temp;
+	bool enabled = false;
+	int key = -1;
 
 	if (((!ts->ts_ops->get_gesture_info) && (!ts->enable_point_auto_change))
         || ((!ts->ts_ops->get_gesture_info_auto) && ts->enable_point_auto_change)) {
@@ -497,6 +514,62 @@ static void tp_gesture_handle(struct touchpanel_data *ts)
              gesture_info_temp.gesture_type == SingleTap ? "single tap" :
 			 gesture_info_temp.gesture_type == PENDETECT ? "(pen detect)" :
              gesture_info_temp.gesture_type == Heart ? "heart" : "unknown");
+
+	switch (gesture_info_temp.gesture_type) {
+		case DouTap:
+			enabled = DouTap_enable;
+			key = KEY_DOUBLE_TAP;
+			break;
+		case UpVee:
+			enabled = UpVee_enable;
+			key = KEY_GESTURE_UP_ARROW;
+			break;
+		case DownVee:
+			enabled = DownVee_enable;
+			key = KEY_GESTURE_DOWN_ARROW;
+			break;
+		case LeftVee:
+			enabled = LeftVee_enable;
+			key = KEY_GESTURE_LEFT_ARROW;
+			break;
+		case RightVee:
+			enabled = RightVee_enable;
+			key = KEY_GESTURE_RIGHT_ARROW;
+			break;
+		case Circle:
+			enabled = Circle_enable;
+			key = KEY_GESTURE_CIRCLE;
+			break;
+		case DouSwip:
+			enabled = DouSwip_enable;
+			key = KEY_GESTURE_TWO_SWIPE;
+			break;
+		case Left2RightSwip:
+			enabled = Left2RightSwip_enable;
+			key = KEY_GESTURE_SWIPE_LEFT;
+			break;
+		case Right2LeftSwip:
+			enabled = Right2LeftSwip_enable;
+			key = KEY_GESTURE_SWIPE_RIGHT;
+			break;
+		case Up2DownSwip:
+			enabled = Up2DownSwip_enable;
+			key = KEY_GESTURE_SWIPE_UP;
+			break;
+		case Down2UpSwip:
+			enabled = Down2UpSwip_enable;
+			key = KEY_GESTURE_SWIPE_DOWN;
+			break;
+		case Mgestrue:
+			enabled = Mgestrue_enable;
+			key = KEY_GESTURE_M;
+			break;
+		case Wgestrue:
+			enabled = Wgestrue_enable;
+			key = KEY_GESTURE_W;
+			break;
+	}
+
 #if GESTURE_COORD_GET
     if (ts->ts_ops->get_gesture_coord) {
         ts->ts_ops->get_gesture_coord(ts->chip_data, gesture_info_temp.gesture_type);
@@ -521,10 +594,12 @@ static void tp_gesture_handle(struct touchpanel_data *ts)
         if(ts->geature_ignore)
             return;
 #endif
-        input_report_key(ts->input_dev, KEY_F4, 1);
-        input_sync(ts->input_dev);
-        input_report_key(ts->input_dev, KEY_F4, 0);
-        input_sync(ts->input_dev);
+        if (enabled) {
+            input_report_key(ts->input_dev, key, 1);
+            input_sync(ts->input_dev);
+            input_report_key(ts->input_dev, key, 0);
+            input_sync(ts->input_dev);
+        }
     } else if (gesture_info_temp.gesture_type == FingerprintDown) {
         ts->fp_info.touch_state = 1;
         if (ts->screenoff_fingerprint_info_support) {
@@ -1690,87 +1765,6 @@ bool tp_boot_mode_normal(void)
 EXPORT_SYMBOL(tp_boot_mode_normal);
 
 /*
- *    gesture_enable = 0 : disable gesture
- *    gesture_enable = 1 : enable gesture when ps is far away
- *    gesture_enable = 2 : disable gesture when ps is near
- *    gesture_enable = 3 : enable single tap gesture when ps is far away
- *    value = 5 : hall status is far way
- *    value = 6 : hall status is near
- */
-static ssize_t proc_gesture_control_write(struct file *file, const char __user *buffer, size_t count, loff_t *ppos)
-{
-    int value = 0;
-    char buf[4] = {0};
-    struct touchpanel_data *ts = PDE_DATA(file_inode(file));
-
-    if (count > 2)
-        return count;
-    if (copy_from_user(buf, buffer, count)) {
-        TPD_INFO("%s: read proc input error.\n", __func__);
-        return count;
-    }
-    if (!ts)
-        return count;
-    if (ts->gesture_test_support && ts->gesture_test.flag) {
-        return count;
-    }
-    sscanf(buf, "%d", &value);
-
-    mutex_lock(&ts->mutex);
-    switch(value) {
-        case 0:
-        case 1:
-        case 2:
-        case 3:
-            if (ts->gesture_enable != value) {
-                ts->gesture_enable = value;
-                if (ts->is_incell_panel && (ts->suspend_state == TP_RESUME_EARLY_EVENT || ts->disable_gesture_ctrl) && (ts->tp_resume_order == LCD_TP_RESUME)) {
-                    TPD_INFO("tp will resume, no need mode_switch in incell panel\n"); /*avoid i2c error or tp rst pulled down in lcd resume*/
-                } else if (ts->is_suspended) {
-                    if (ts->fingerprint_underscreen_support && ts->fp_enable && ts->ts_ops->enable_gesture_mask) {
-                        ts->ts_ops->enable_gesture_mask(ts->chip_data, (ts->gesture_enable & 0x01) == 1);
-                    } else {
-                        operate_mode_switch(ts);
-                    }
-                }
-            } 
-            break;
-        case 4:
-            break;
-        case 5:
-            ts->hall_status = false;
-            break;
-        case 6:
-            ts->hall_status = true;
-            if ((ts->gesture_enable & 0x01) && ts->is_suspended)
-                operate_mode_switch(ts);
-            break;
-        default:
-            TPD_DEBUG("invalid setting %d\n", value);
-    }
-    TPD_INFO("%s: gesture_enable = %d, value = %d\n", __func__, ts->gesture_enable, value);
-    mutex_unlock(&ts->mutex);
-
-    return count;
-}
-
-static ssize_t proc_gesture_control_read(struct file *file, char __user *user_buf, size_t count, loff_t *ppos)
-{
-    int ret = 0;
-    char page[PAGESIZE] = {0};
-    struct touchpanel_data *ts = PDE_DATA(file_inode(file));
-
-    if (!ts)
-        return 0;
-
-    TPD_DEBUG("double tap enable is: %d\n", ts->gesture_enable);
-    ret = snprintf(page, PAGESIZE - 1, "%d", ts->gesture_enable);
-    ret = simple_read_from_buffer(user_buf, count, ppos, page, strlen(page));
-
-    return ret;
-}
-
-/*
  *    each bit cant enable or disable each gesture
  *    bit0: 1 for enable bit gesture, 0 for disable bit gesture
  *    bit1: 1 for enable bit gesture, 0 for disable bit gesture
@@ -1846,13 +1840,6 @@ static ssize_t proc_coordinate_read(struct file *file, char __user *user_buf, si
 
     return ret;
 }
-
-static const struct file_operations proc_gesture_control_fops = {
-    .write = proc_gesture_control_write,
-    .read  = proc_gesture_control_read,
-    .open  = simple_open,
-    .owner = THIS_MODULE,
-};
 
 static const struct file_operations proc_gesture_control_indep_fops = {
     .write = proc_gesture_control_indep_write,
@@ -4450,6 +4437,55 @@ static const struct file_operations proc_touch_apk_fops = {
 
 #endif //end of CONFIG_OPLUS_TP_APK
 
+#define GESTURE_ATTR(name, out) \
+	static ssize_t name##_enable_read_func(struct file *file, char __user *user_buf, size_t count, loff_t *ppos) \
+	{ \
+		int ret = 0; \
+		char page[PAGESIZE]; \
+		ret = sprintf(page, "%d\n", out); \
+		ret = simple_read_from_buffer(user_buf, count, ppos, page, strlen(page)); \
+		return ret; \
+	} \
+	static ssize_t name##_enable_write_func(struct file *file, const char __user *user_buf, size_t count, loff_t *ppos) \
+	{ \
+		int enabled = 0; \
+		char page[PAGESIZE] = {0}; \
+		copy_from_user(page, user_buf, count); \
+		sscanf(page, "%d", &enabled); \
+		out = enabled > 0 ? 1 : 0; \
+		return count; \
+	} \
+	static const struct file_operations name##_enable_proc_fops = { \
+	    .write = name##_enable_write_func, \
+	    .read =  name##_enable_read_func, \
+	    .open = simple_open, \
+	    .owner = THIS_MODULE, \
+	};
+
+GESTURE_ATTR(double_tap, DouTap_enable);
+GESTURE_ATTR(up_arrow, UpVee_enable);
+GESTURE_ATTR(down_arrow, DownVee_enable);
+GESTURE_ATTR(left_arrow, LeftVee_enable);
+GESTURE_ATTR(right_arrow, RightVee_enable);
+GESTURE_ATTR(double_swipe, DouSwip_enable);
+GESTURE_ATTR(up_swipe, Up2DownSwip_enable);
+GESTURE_ATTR(down_swipe, Down2UpSwip_enable);
+GESTURE_ATTR(left_swipe, Left2RightSwip_enable);
+GESTURE_ATTR(right_swipe, Right2LeftSwip_enable);
+GESTURE_ATTR(letter_o, Circle_enable);
+GESTURE_ATTR(letter_w, Wgestrue_enable);
+GESTURE_ATTR(letter_m, Mgestrue_enable);
+
+#define CREATE_PROC_NODE(PARENT, NAME, MODE) \
+	prEntry_tmp = proc_create(#NAME, MODE, PARENT, &NAME##_proc_fops); \
+	if (prEntry_tmp == NULL) { \
+		ret = -ENOMEM; \
+		TPD_INFO("%s: Couldn't create proc entry, %d\n", __func__, __LINE__); \
+	}
+
+#define CREATE_GESTURE_NODE(NAME) \
+	CREATE_PROC_NODE(prEntry_tp, NAME##_enable, 0666)
+
 /**
  * init_touchpanel_proc - Using for create proc interface
  * @ts: touchpanel_data struct using for common driver
@@ -4529,11 +4565,20 @@ static int init_touchpanel_proc(struct touchpanel_data *ts)
 
     //proc files-step2-4:/proc/touchpanel/double_tap_enable (black gesture related interface)
     if (ts->black_gesture_support) {
-        prEntry_tmp = proc_create_data("double_tap_enable", 0666, prEntry_tp, &proc_gesture_control_fops, ts);
-        if (prEntry_tmp == NULL) {
-            ret = -ENOMEM;
-            TPD_INFO("%s: Couldn't create proc entry, %d\n", __func__, __LINE__);
-        }
+        CREATE_GESTURE_NODE(double_tap);
+        CREATE_GESTURE_NODE(up_arrow);
+        CREATE_GESTURE_NODE(down_arrow);
+        CREATE_GESTURE_NODE(left_arrow);
+        CREATE_GESTURE_NODE(right_arrow);
+        CREATE_GESTURE_NODE(double_swipe);
+        CREATE_GESTURE_NODE(up_swipe);
+        CREATE_GESTURE_NODE(down_swipe);
+        CREATE_GESTURE_NODE(left_swipe);
+        CREATE_GESTURE_NODE(right_swipe);
+        CREATE_GESTURE_NODE(letter_o);
+        CREATE_GESTURE_NODE(letter_w);
+        CREATE_GESTURE_NODE(letter_m);
+
         prEntry_tmp = proc_create_data("coordinate", 0444, prEntry_tp, &proc_coordinate_fops, ts);
         if (prEntry_tmp == NULL) {
             ret = -ENOMEM;
@@ -6260,6 +6305,21 @@ static int init_input_device(struct touchpanel_data *ts)
 #ifdef CONFIG_OPLUS_TP_APK
         set_bit(KEY_POWER, ts->input_dev->keybit);
 #endif //end of CONFIG_OPLUS_TP_APK
+        set_bit(KEY_GESTURE_W, ts->input_dev->keybit);
+        set_bit(KEY_GESTURE_M, ts->input_dev->keybit);
+        set_bit(KEY_GESTURE_S, ts->input_dev->keybit);
+        set_bit(KEY_DOUBLE_TAP, ts->input_dev->keybit);
+        set_bit(KEY_GESTURE_CIRCLE, ts->input_dev->keybit);
+        set_bit(KEY_GESTURE_TWO_SWIPE, ts->input_dev->keybit);
+        set_bit(KEY_GESTURE_UP_ARROW, ts->input_dev->keybit);
+        set_bit(KEY_GESTURE_LEFT_ARROW, ts->input_dev->keybit);
+        set_bit(KEY_GESTURE_RIGHT_ARROW, ts->input_dev->keybit);
+        set_bit(KEY_GESTURE_DOWN_ARROW, ts->input_dev->keybit);
+        set_bit(KEY_GESTURE_SWIPE_LEFT, ts->input_dev->keybit);
+        set_bit(KEY_GESTURE_SWIPE_DOWN, ts->input_dev->keybit);
+        set_bit(KEY_GESTURE_SWIPE_RIGHT, ts->input_dev->keybit);
+        set_bit(KEY_GESTURE_SWIPE_UP, ts->input_dev->keybit);
+        set_bit(KEY_GESTURE_SINGLE_TAP, ts->input_dev->keybit);
     }
 
     ts->kpd_input_dev->name = TPD_DEVICE"_kpd";
@@ -7754,7 +7814,7 @@ int register_common_touch_device(struct touchpanel_data *pdata)
     ts->hall_status = false;
     ts->is_suspended = 0;
     ts->suspend_state = TP_SPEEDUP_RESUME_COMPLETE;
-    ts->gesture_enable = 0;
+    ts->gesture_enable = 1;
     ts->es_enable = 0;
     ts->fd_enable = 0;
     ts->fp_enable = 0;


### PR DESCRIPTION
This is a relatively simple change that should allow for both better performance on the small A55 cores, but also the A78 cores, which should boost performance and power efficiency.

As for why mtune has been removed, it is because it is redundant with the mcpu arguments on ARM, and actually doesn't make the fastest non native binaries possible. Because of that, I've removed it.

Source for my claim:
https://community.arm.com/arm-community-blogs/b/tools-software-ides-blog/posts/compiler-flags-across-architectures-march-mtune-and-mcpu

Note that I do not know if it currently builds, as I have not set up my build stuff yet.